### PR TITLE
feat(header): Override armory-header with the latest release

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -10,7 +10,7 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
 # and https://cloud.google.com/appengine/docs/standard/java/release-notes
     GOOGLE_CLOUD_SDK_VERSION=396.0.0 \
     ECR_TOKEN_VERSION=v1.0.2
-    
+
 ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator:/opt/ecr-token"
 
 RUN apk update && \
@@ -82,10 +82,18 @@ COPY --from=armory/clouddriver-armory:2022.08.03.03.46.46.release-2.28.x /opt/cl
 
 COPY --from=armory/deck-armory:2022.07.14.16.52.46.release-2.28.x /opt/deck/html  /opt/deck/html
 
-COPY spinnaker-config/settings.js spinnaker-config/plugin-manifest.json /opt/deck/html
+COPY spinnaker-config/settings.js spinnaker-config/plugin-manifest.json /opt/deck/html/
 
 # -- Install gate --
 COPY --from=armory/gate-armory:2022.08.03.03.23.19.release-2.28.x /opt/gate /opt/gate
+
+# -- Override armory-header plugin --
+RUN wget https://github.com/armory-plugins/armory-header/releases/download/v0.1.1/armory-header-v0.1.1.zip \
+    && mv ./armory-header-v0.1.1.zip /opt/gate/plugins/ \
+    && cd /opt/gate/plugins \
+    && rm -rf armory-header-v0.1.0 armory-header-v0.1.0.zip Armory.ArmoryHeader-armory-header-v0.1.0 Armory.ArmoryHeader-armory-header-v0.1.0.zip
+
+COPY spinnaker-config/deck-plugins/plugins.json /opt/gate/local-plugin-repo/
 
 # -- Install orca --
 

--- a/Docker/spinnaker-config/deck-plugins/plugins.json
+++ b/Docker/spinnaker-config/deck-plugins/plugins.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "Armory.ArmoryHeader",
+    "description": "A plugin that overrides Spinnaker Header",
+    "provider": "https://github.com/armory-plugins",
+    "releases": [
+      {
+        "version": "0.1.1",
+        "date": "2022-08-26T18:11:12.110249Z",
+        "requires": "deck>=0.0.0",
+        "sha512sum": "117a7956f169f4b7837619dabc9d38702852f3f8fa0e4c89907bf0a70957febc780d284c296c7abd7c5b4bb65e4e18d9699dc074b3c195a7d5512831bfdbdba4",
+        "url": "file:///opt/gate/plugins/armory-header-v0.1.1.zip"
+      }
+    ]
+  }
+]

--- a/Docker/spinnaker-config/settings.js
+++ b/Docker/spinnaker-config/settings.js
@@ -119,6 +119,7 @@ window.spinnakerSettings = {
     fiatEnabled: fiatEnabled,
     pipelineTemplates: pipelineTemplatesEnabled,
     roscoMode: true,
+    quickSpinEnabled: true
   },
   gateUrl: gateHost,
   notifications: {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ How to?
 
 ```bash
 # build
-docker build -t spin .
+docker build -t spin ./Docker
 
 # run
 docker run -p 9000:80 --name=spin spin


### PR DESCRIPTION
Manually copy the armory-header. This is to avoid creating a new release for deck and gate.