### PR TITLE
fix(k8s): infrastructure not appearing for kubernetes deployments

### DIFF
--- a/Docker/spinnaker-config/clouddriver.yml
+++ b/Docker/spinnaker-config/clouddriver.yml
@@ -86,7 +86,7 @@ kubernetes:
     kinds: []
     liveManifestCalls: false
     name: spinnaker
-    namespaces: [default]
+    namespaces: []
     oAuthScopes: []
     omitKinds: [podPreset]
     omitNamespaces: []


### PR DESCRIPTION
Due to caching the server groups are expected to appear in maximum 5min (from clouddrive source code). With this configuration in quick-spin, they appear in ~3min. 